### PR TITLE
Fix LCD jogging not working

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -276,7 +276,7 @@ extern float current_position[NUM_AXIS];
 #endif
 
 // Software Endstops
-extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
+extern volatile float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
 
 #if HAS_SOFTWARE_ENDSTOPS
   extern bool soft_endstops_enabled;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -515,7 +515,7 @@ float filament_size[EXTRUDERS], volumetric_multiplier[EXTRUDERS];
 #if HAS_SOFTWARE_ENDSTOPS
   bool soft_endstops_enabled = true;
 #endif
-float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
+volatile float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
       soft_endstop_max[XYZ] = { X_MAX_BED, Y_MAX_BED, Z_MAX_POS };
 
 #if FAN_COUNT > 0


### PR DESCRIPTION
I had the same issue as what you described. After some digging, it turned out that the mixed usage of the soft_endstop_min and max arrays with constant indexing (in almost all Marlin functions) or as a variable with variable indexing (in the DWIN jog function) caused issues, the DWIN function was not getting the right variable. Perhaps some compiler shenanigan that wasn't there a few years ago?
Anyway, declaring it volatile makes the compiler always actually look at the variable, this fixes it